### PR TITLE
Update Dockerfile.rethinkdb

### DIFF
--- a/Dockerfiles/Dockerfile.rethinkdb
+++ b/Dockerfiles/Dockerfile.rethinkdb
@@ -1,4 +1,4 @@
-# Set the base image to node
+# Set the base image to rethinkdb
 FROM rethinkdb:latest
 
 MAINTAINER Max Campbell <maxc@maxc.in>


### PR DESCRIPTION
fixed comment stating that the base image was node when in fact it was rethinkdb